### PR TITLE
Support 'cipher' field for (audio) formats

### DIFF
--- a/lib/src/internal/parsers/adaptive_stream_cipher_parser.dart
+++ b/lib/src/internal/parsers/adaptive_stream_cipher_parser.dart
@@ -1,0 +1,16 @@
+class AdaptiveStreamCipherParser {
+  Map<String, dynamic> _root;
+
+  AdaptiveStreamCipherParser(this._root);
+
+  String parseUrl() => _root['url'];
+
+  String parseSignature() => _root['s'];
+
+  String parseSp() => _root['sp'];
+
+  static AdaptiveStreamCipherParser initialize(String raw) {
+    var query = Uri.splitQueryString(raw);
+    return AdaptiveStreamCipherParser(query);
+  }
+}

--- a/lib/src/internal/parsers/adaptive_stream_info_parser.dart
+++ b/lib/src/internal/parsers/adaptive_stream_info_parser.dart
@@ -1,3 +1,5 @@
+import 'adaptive_stream_cipher_parser.dart';
+
 class AdaptiveStreamInfoParser {
   Map<String, dynamic> _root;
 
@@ -26,6 +28,11 @@ class AdaptiveStreamInfoParser {
       _root['url']; //_root["size"].SubstringAfter('x').ParseInt();
 
   int parseWidth() => 0;
+
+  AdaptiveStreamCipherParser parseCipher() {
+    if (!_root.containsKey('cipher')) return null;
+    return AdaptiveStreamCipherParser.initialize(_root['cipher']);
+  }
 
   int _getInt(String string) {
     if (string == null) {

--- a/lib/youtube_extractor.dart
+++ b/lib/youtube_extractor.dart
@@ -102,20 +102,25 @@ class YouTubeExtractor {
 
       // If content length is 0, it means that the stream is gone or faulty
       if (contentLength > 0) {
+        // Extract cipher if needed
+        var cipher = adaptiveStreamInfo[i].parseCipher();
+
         // Extract URL
-        var url = adaptiveStreamInfo[i].parseUrl();
+        var url = cipher?.parseUrl() ?? adaptiveStreamInfo[i].parseUrl();
 
         // Decipher signature if needed
-        var signature = adaptiveStreamInfo[i].parseSignature();
+        var signature =
+            cipher?.parseSignature() ?? adaptiveStreamInfo[i].parseSignature();
         if (signature != null) {
           var playerSource = await _getVideoPlayerSourceAsync(playerSourceUrl);
           signature = playerSource.decipher(signature);
 
           // parameter 'ratebypass' needs to be yes
           // if there is 'sp' parameter, must use 'sig' instead of 'signature'
-          if (adaptiveStreamInfo[i].parseSp() != null) {
+          var sp = cipher?.parseSp() ?? adaptiveStreamInfo[i].parseSp();
+          if (sp != null) {
             url = url +
-                '&ratebypass=yes&${adaptiveStreamInfo[i].parseSp()}=' +
+                '&ratebypass=yes&$sp=' +
                 signature;
           } else {
             url = url + '&ratebypass=yes&signature=' + signature;


### PR DESCRIPTION
Some videos return `null` for the `url` field on their audio streams. (e.g. ZB75e7vzX0I)
This seems to be due to the fact that they lack the `url` field, and instead have an additional `cipher` field which contains the url, signature and "sp".
This PR tries to parse the `cipher` field first, with the original fields on the adaptive stream info as a fallback.

I have only tested it for audio streams, not the video or muxed ones. 
